### PR TITLE
Add isometry() function to C++ Transformation

### DIFF
--- a/include/spatial_transformation/transformation.hpp
+++ b/include/spatial_transformation/transformation.hpp
@@ -54,7 +54,10 @@ public:
     Transformation inverse() const;
 
     //! Convert transformation to a homogeneous matrix (4x4).
-    Eigen::Matrix4d matrix() const;  // TODO use Isometry3d instead of matrix?
+    Eigen::Matrix4d matrix() const;
+
+    //! Convert transformation to an isometry.
+    Eigen::Isometry3d isometry() const;
 
     // for serialisation
     template <class Archive>

--- a/src/transformation.cpp
+++ b/src/transformation.cpp
@@ -55,8 +55,13 @@ Transformation Transformation::inverse() const
 
 Eigen::Matrix4d Transformation::matrix() const
 {
-    Eigen::Affine3d tf = Eigen::Translation3d(translation) * rotation;
-    return tf.matrix();
+    return isometry().matrix();
+}
+
+Eigen::Isometry3d Transformation::isometry() const
+{
+    Eigen::Isometry3d iso = Eigen::Translation3d(translation) * rotation;
+    return iso;
 }
 
 EulerTransform::EulerTransform()


### PR DESCRIPTION
This returns an Eigen::Isometry3d which is a thin wrapper around a 4x4 matrix with easier access to rotational and translational parts.