### PR TITLE
doc: Add basic documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # spatial_transformation
 
-Utility package that provides classes and functions to handle spatial
-transformations in both C++ and Python.
+Utility package for working with spatial transformations in both C++ and Python.
+
+**Documentation:**
+https://intelligent-soft-robots.github.io/spatial_transformation
+
+Copyright &copy; 2023 Max Planck Gesellschaft
+License: [BSD-3-clause](LICENSE)

--- a/doc/breathing_cat.toml
+++ b/doc/breathing_cat.toml
@@ -3,7 +3,9 @@ exclude_patterns = ["json.hpp", "fmt.hpp", "{{PACKAGE_DIR}}/srcpy/*"]
 
 [intersphinx.mapping]
 pam_documentation = "https://intelligent-soft-robots.github.io/pam_documentation"
+scipy = "https://docs.scipy.org/doc/scipy/"
+numpy = "https://numpy.org/doc/stable/"
 
-# [mainpage]
-# title = "Custom Title"
-# auto_general_docs = false
+[mainpage]
+#title = "Custom Title"
+auto_general_docs = false

--- a/doc_mainpage.rst
+++ b/doc_mainpage.rst
@@ -1,0 +1,53 @@
+``spatial_transformation`` is a utility package for working with spatial transformations
+in both C++ and Python.
+
+The code is hosted on GitHub_.
+
+.. .. toctree::
+..    :caption: General Documentation
+..    :maxdepth: 1
+
+
+The Transformation Class
+========================
+
+This package contains native implementations of a ``Transformation`` class in both
+Python and C++.  They work very similarly but differ a bit in some details, mostly
+regarding data types used for the rotation (scipy's Rotation class in Python vs Eigen's
+Quaternion in C++).
+
+- Python: :py:class:`spatial_transformation.Transformation`
+- C++: :cpp:class:`spatial_transformation::Transformation`
+
+There are also Python bindings for the C++ version
+(:class:`spatial_transformation.cpp.Transformation`), so it can be used in other
+bindings (e.g. a function that returns a transformation).  However, when working in
+Python, the native implementation provides more flexibility, so you may want to convert
+it.  The Python class implements methods
+:meth:`~spatial_transformation.Transformation.from_cpp` and
+:meth:`~spatial_transformation.Transformation.as_cpp` for this purpose.
+
+
+Compute Transformation Between Different Systems
+================================================
+
+The ``pointcloud`` library provides utility functions for computing the transformation
+between two different reference frames, given the positions of a set of points in both
+frames.  For more information see :doc:`breathe_apidoc/file/pointcloud_8hpp`.
+
+
+Use in CMake Project
+====================
+
+.. code-block:: cmake
+
+   find_package(spatial_transformation REQUIRED)
+
+   add_library(mylib ...)
+   target_link_libraries(mylib
+     spatial_transformation::transformation  # for the Transformation class
+     spatial_transformation::pointcloud  # for point cloud transformation computation
+   )
+
+
+.. _GitHub: https://github.com/MPI-IS/spatial_transformation

--- a/package.xml
+++ b/package.xml
@@ -7,8 +7,8 @@ schematypens="http://www.w3.org/2001/XMLSchema"?>
     <name>spatial_transformation</name>
     <version>0.9.0</version>
     <description>
-        Utility package that provides classes and functions to handle spatial
-        transformations in both C++ and Python.
+        Utility package for working with spatial transformations in both C++ and
+        Python.
     </description>
     <author email="felix.widmaier@tue.mpg.de">Felix Widmaier</author>
     <maintainer email="felix.widmaier@tue.mpg.de">Felix Widmaier</maintainer>

--- a/spatial_transformation/__init__.py
+++ b/spatial_transformation/__init__.py
@@ -2,3 +2,6 @@
 """Utility package for working with spatial transformations."""
 
 from ._transformation import Transformation, Rotation
+
+
+__all__ = ("Transformation",)

--- a/spatial_transformation/_transformation.py
+++ b/spatial_transformation/_transformation.py
@@ -14,7 +14,17 @@ if typing.TYPE_CHECKING:
 
 
 class Transformation:
-    """Represents a 3d-transformation consisting of rotation and translation."""
+    """Represents a 3d-transformation consisting of rotation and translation.
+
+    The transformation consists of a rotation R and a translation T with the
+    rotation being applied first.  So the transformed version v' of a vector v is
+    computed as ``v' = R*v + T``.
+    """
+
+    rotation: Rotation
+    """Rotation part of the transformation."""
+    translation: np.ndarray
+    """Translation part of the transformation."""
 
     def __init__(
         self,
@@ -53,7 +63,7 @@ class Transformation:
 
     @classmethod
     def from_cpp(cls, cpp_tf: cpp.Transformation) -> Transformation:
-        """Construct from cpp.Transformation."""
+        """Construct from :class:`cpp.Transformation`."""
         return cls(rotation=cpp_tf.get_rotation(), translation=cpp_tf.translation)
 
     def __mul__(self, other: Transformation) -> Transformation:
@@ -80,7 +90,7 @@ class Transformation:
         return mat
 
     def as_cpp(self) -> cpp.Transformation:
-        """Convert to cpp.Transformation."""
+        """Convert to :class:`cpp.Transformation`."""
         cpp_tf = cpp.Transformation()
         cpp_tf.translation = self.translation
         cpp_tf.set_rotation(self.rotation.as_quat())


### PR DESCRIPTION
Note: It seems `__all__` in `__init__.py` is needed to make the `Transformation` class appear in the Sphinx documentation.